### PR TITLE
Add m1 platform specs to Gemfile lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,8 @@ GEM
     minitest (5.15.0)
     msgpack (1.4.5)
     nio4r (2.5.8)
+    nokogiri (1.13.3-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.3-x86_64-darwin)
       racc (~> 1.4)
     pg (1.3.3)
@@ -223,6 +225,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-19
 
 DEPENDENCIES


### PR DESCRIPTION
My machine did it by default